### PR TITLE
Configure "templates" via the icinga2_host resource

### DIFF
--- a/icinga2/resource_icinga2_host.go
+++ b/icinga2/resource_icinga2_host.go
@@ -35,6 +35,14 @@ func resourceIcinga2Host() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"templates": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -55,8 +63,13 @@ func resourceIcinga2HostCreate(d *schema.ResourceData, meta interface{}) error {
 		vars[key] = value.(string)
 	}
 
+	templates := make([]string, len(d.Get("templates").([]interface{})))
+	for i, v := range d.Get("templates").([]interface{}) {
+		templates[i] = v.(string)
+	}
+
 	// Call CreateHost with normalized data
-	hosts, err := client.CreateHost(hostname, address, checkCommand, vars)
+	hosts, err := client.CreateHost(hostname, address, checkCommand, vars, templates)
 	if err != nil {
 		return err
 	}

--- a/icinga2/resource_icinga2_host_test.go
+++ b/icinga2/resource_icinga2_host_test.go
@@ -69,6 +69,33 @@ func TestAccCreateVariableHost(t *testing.T) {
 	})
 }
 
+func TestAccCreateTemplateHost(t *testing.T) {
+	testAccCreateTemplateHost := `resource "icinga2_host" "tf-4" {
+	hostname = "terraform-host-4"
+	address = "10.10.10.4"
+	check_command = "hostalive"
+	templates = ["generic", "az1"]
+}`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCreateTemplateHost,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostExists("icinga2_host.tf-4"),
+					testAccCheckResourceState("icinga2_host.tf-4", "hostname", "terraform-host-4"),
+					testAccCheckResourceState("icinga2_host.tf-4", "address", "10.10.10.4"),
+					testAccCheckResourceState("icinga2_host.tf-4", "check_command", "hostalive"),
+					testAccCheckResourceState("icinga2_host.tf-4", "templates.#", "2"),
+					testAccCheckResourceState("icinga2_host.tf-4", "templates.0", "generic"),
+					testAccCheckResourceState("icinga2_host.tf-4", "templates.1", "az1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckHostExists(rn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources[rn]

--- a/icinga2/resource_icinga2_service_test.go
+++ b/icinga2/resource_icinga2_service_test.go
@@ -19,8 +19,8 @@ func TestAccCreateService(t *testing.T) {
 		check_command = "ssh"
 	}`)
 	hostname := "docker-icinga2"
-	icinga2Server := testAccProvider.Meta().(*iapi.Server)
 	createHost := func() {
+		icinga2Server := testAccProvider.Meta().(*iapi.Server)
 		icinga2Server.CreateHost(hostname, "10.0.0.1", "hostalive", nil, nil)
 	}
 
@@ -41,6 +41,7 @@ func TestAccCreateService(t *testing.T) {
 		},
 	})
 
+	icinga2Server := testAccProvider.Meta().(*iapi.Server)
 	err := icinga2Server.DeleteHost(hostname)
 	if err != nil {
 		t.Errorf("Error deleting host object after test completed: %s", err)

--- a/vendor/github.com/lrsmith/go-icinga2-api/iapi/hosts.go
+++ b/vendor/github.com/lrsmith/go-icinga2-api/iapi/hosts.go
@@ -33,12 +33,13 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 }
 
 // CreateHost ...
-func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string) ([]HostStruct, error) {
+func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string, templates []string) ([]HostStruct, error) {
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
 	newAttrs.CheckCommand = "hostalive"
 	newAttrs.Vars = variables
+	newAttrs.Templates = templates
 
 	var newHost HostStruct
 	newHost.Name = hostname

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -489,10 +489,10 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
-			"checksumSHA1": "8fIVetxvijD+9nPT5TEl2OeDHxg=",
+			"checksumSHA1": "5vT6l22kAQVXWOT1YI5bhLQ9kBA=",
 			"path": "github.com/lrsmith/go-icinga2-api/iapi",
-			"revision": "ba9eccb088d652b05154765828ad78345bc36f14",
-			"revisionTime": "2016-12-10T04:55:21Z"
+			"revision": "7b46d425cc71344e4357bf0bcc873e93723d1dc7",
+			"revisionTime": "2017-07-26T19:48:34Z"
 		},
 		{
 			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",


### PR DESCRIPTION
This PR adds support for setting templates of a Icinga2 Host.
The provider is now on par with the docs that state that templates are supported by the `icinga2_host` resource.

The acceptance test `TestAccCreateService` has been altered in this PR because it falsely assumed that a Icinga2 Host object exists.