### PR TITLE
Feature/optionally support groups for hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 0.1.2 (Unreleased)
+
+ENHANCEMENTS:
+
+ * resource/resource_icinga2_host: Add optional parameter to support declaring groups when creating hosts.
+
+BUGS:
+ * resource/resource_icinga2_host: govend latest go-icinga2-api with optionaly declaring groups when creating a host. ([GH-1](https://github.com/terraform-providers/terraform-provider-icinga2/issues/1))
+
 ## 0.1.1 (August 04, 2017)
 
  * Configure "templates" via the icinga2_host resource ([#3](https://github.com/terraform-providers/terraform-provider-icinga2/issues/3))

--- a/icinga2/resource_icinga2_host.go
+++ b/icinga2/resource_icinga2_host.go
@@ -32,7 +32,7 @@ func resourceIcinga2Host() *schema.Resource {
 			},
 			"groups": &schema.Schema{
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/icinga2/resource_icinga2_host.go
+++ b/icinga2/resource_icinga2_host.go
@@ -30,6 +30,14 @@ func resourceIcinga2Host() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"groups": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"vars": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -57,6 +65,11 @@ func resourceIcinga2HostCreate(d *schema.ResourceData, meta interface{}) error {
 
 	vars := make(map[string]string)
 
+	groups := make([]string, len(d.Get("groups").([]interface{})))
+	for i, v := range d.Get("groups").([]interface{}) {
+		groups[i] = v.(string)
+	}
+
 	// Normalize from map[string]interface{} to map[string]string
 	iterator := d.Get("vars").(map[string]interface{})
 	for key, value := range iterator {
@@ -69,7 +82,7 @@ func resourceIcinga2HostCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Call CreateHost with normalized data
-	hosts, err := client.CreateHost(hostname, address, checkCommand, vars, templates)
+	hosts, err := client.CreateHost(hostname, address, checkCommand, vars, templates, groups)
 	if err != nil {
 		return err
 	}

--- a/icinga2/resource_icinga2_host_test.go
+++ b/icinga2/resource_icinga2_host_test.go
@@ -16,7 +16,6 @@ func TestAccCreateBasicHost(t *testing.T) {
 		hostname      = "terraform-host-1"
 		address       = "10.10.10.1"
 		check_command = "hostalive"
-		groups = ["linux-servers"]
 	}`)
 
 	resource.Test(t, resource.TestCase{
@@ -36,6 +35,35 @@ func TestAccCreateBasicHost(t *testing.T) {
 	})
 }
 
+func TestAccCreateGroupHost(t *testing.T) {
+
+	var testAccCreateBasicHost = fmt.Sprintf(`
+                resource "icinga2_host" "tf-2" {
+                hostname      = "terraform-host-2"
+                address       = "10.10.10.2"
+                check_command = "hostalive"
+		groups = ["linux-servers"]
+        }`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCreateBasicHost,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHostExists("icinga2_host.tf-2"),
+					testAccCheckResourceState("icinga2_host.tf-2", "hostname", "terraform-host-2"),
+					testAccCheckResourceState("icinga2_host.tf-2", "address", "10.10.10.2"),
+					testAccCheckResourceState("icinga2_host.tf-2", "check_command", "hostalive"),
+					testAccCheckResourceState("icinga2_host.tf-2", "groups.#", "1"),
+					testAccCheckResourceState("icinga2_host.tf-2", "groups.0", "linux-servers"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCreateVariableHost(t *testing.T) {
 
 	var testAccCreateVariableHost = fmt.Sprintf(`
@@ -43,7 +71,6 @@ func TestAccCreateVariableHost(t *testing.T) {
 		hostname = "terraform-host-3"
 		address = "10.10.10.3"
 		check_command = "hostalive"
-		groups = ["linux-servers"]
 		vars {
 		  os = "linux"
 		  osver = "1"
@@ -76,7 +103,6 @@ func TestAccCreateTemplateHost(t *testing.T) {
 	hostname = "terraform-host-4"
 	address = "10.10.10.4"
 	check_command = "hostalive"
-	groups = ["linux-servers"]
 	templates = ["generic", "az1"]
 }`
 	resource.Test(t, resource.TestCase{

--- a/icinga2/resource_icinga2_host_test.go
+++ b/icinga2/resource_icinga2_host_test.go
@@ -16,6 +16,7 @@ func TestAccCreateBasicHost(t *testing.T) {
 		hostname      = "terraform-host-1"
 		address       = "10.10.10.1"
 		check_command = "hostalive"
+		groups = ["linux-servers"]
 	}`)
 
 	resource.Test(t, resource.TestCase{
@@ -42,6 +43,7 @@ func TestAccCreateVariableHost(t *testing.T) {
 		hostname = "terraform-host-3"
 		address = "10.10.10.3"
 		check_command = "hostalive"
+		groups = ["linux-servers"]
 		vars {
 		  os = "linux"
 		  osver = "1"
@@ -74,6 +76,7 @@ func TestAccCreateTemplateHost(t *testing.T) {
 	hostname = "terraform-host-4"
 	address = "10.10.10.4"
 	check_command = "hostalive"
+	groups = ["linux-servers"]
 	templates = ["generic", "az1"]
 }`
 	resource.Test(t, resource.TestCase{

--- a/icinga2/resource_icinga2_service_test.go
+++ b/icinga2/resource_icinga2_service_test.go
@@ -19,9 +19,10 @@ func TestAccCreateService(t *testing.T) {
 		check_command = "ssh"
 	}`)
 	hostname := "docker-icinga2"
+	Groups := []string{"linux-servers"}
 	createHost := func() {
 		icinga2Server := testAccProvider.Meta().(*iapi.Server)
-		icinga2Server.CreateHost(hostname, "10.0.0.1", "hostalive", nil, nil)
+		icinga2Server.CreateHost(hostname, "10.0.0.1", "hostalive", nil, nil, Groups)
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/vendor/github.com/lrsmith/go-icinga2-api/.gitignore
+++ b/vendor/github.com/lrsmith/go-icinga2-api/.gitignore
@@ -1,0 +1,1 @@
+JSON_Examples

--- a/vendor/github.com/lrsmith/go-icinga2-api/.travis.yml
+++ b/vendor/github.com/lrsmith/go-icinga2-api/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+
+language: go
+
+go:
+  - 1.7.x
+
+services:
+  - docker
+
+before_install:
+  - make start_test_icinga2
+  - docker ps -a
+
+script: go test -v ./...
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/lrsmith/go-icinga2-api/Makefile
+++ b/vendor/github.com/lrsmith/go-icinga2-api/Makefile
@@ -1,0 +1,5 @@
+start_test_icinga2:
+	docker run -d --name icinga2 -p 8080:80 -p 8443:443 -p 5665:5665 -it jordan/icinga2:latest
+	sleep 60
+	docker exec icinga2 bash -c 'echo -e "object ApiUser \"icinga-test\" {\n  password = \"icinga\"\n  permissions = [ \"*\" ]\n}" > /etc/icinga2/conf.d/test-api-user.conf'
+	docker exec icinga2 supervisorctl restart icinga2

--- a/vendor/github.com/lrsmith/go-icinga2-api/README.md
+++ b/vendor/github.com/lrsmith/go-icinga2-api/README.md
@@ -1,0 +1,29 @@
+# go-icinga2-api
+
+go-icinga2-api is a Go client library for configuring Icinga2 server via the [Icinga2 API](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/icinga2-api)
+
+[![Build Status](https://travis-ci.org/lrsmith/go-icinga2-api.svg?branch=master)](https://travis-ci.org/lrsmith/go-icinga2-api)
+[![Go Report Card](https://goreportcard.com/badge/github.com/lrsmith/go-icinga2-api)](https://goreportcard.com/report/github.com/lrsmith/go-icinga2-api)
+[![codecov](https://codecov.io/gh/lrsmith/go-icinga2-api/branch/mas-aptet/graph/badge.svg)](https://codecov.io/gh/lrsmith/go-icinga2-api)
+
+
+## Motivation
+
+This library is being written to learn Go and also to provide the framework for a [Terraform](https://www.terraform.io/) Icinga2 Provider. An [initial implementation](https://github.com/lrsmith/terraform-provider-icinga2) was done but was not portable, so this project was started to provide a more general client library for Go which could be leveraged for refactoring the Terraform
+providers.
+
+## License
+
+This software is licensed under the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/)
+
+## Contributing
+
+This is a work in progress both for learning Go and getting some needed tooling. Any constructive feedback
+or comments will be taken. Also contributions via Pull Requests will be accepted. Ideally any code contributions
+should include or extend the existing tests.
+
+# To Do
+* Extend CreateHost to allow setting the remaining items in HostAttrs.
+* Refactor DeleteHost so Cascade is a configurable option.
+
+golang

--- a/vendor/github.com/lrsmith/go-icinga2-api/TODO.md
+++ b/vendor/github.com/lrsmith/go-icinga2-api/TODO.md
@@ -1,0 +1,2 @@
+* Create of existing object fails with '500 Object could not be created' 
+This should only be an error is passed parameters do not match 100% else its not an error

--- a/vendor/github.com/lrsmith/go-icinga2-api/iapi/hosts.go
+++ b/vendor/github.com/lrsmith/go-icinga2-api/iapi/hosts.go
@@ -33,13 +33,14 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 }
 
 // CreateHost ...
-func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string, templates []string) ([]HostStruct, error) {
+func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string, templates []string, groups []string) ([]HostStruct, error) {
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
 	newAttrs.CheckCommand = "hostalive"
 	newAttrs.Vars = variables
 	newAttrs.Templates = templates
+	newAttrs.Groups = groups
 
 	var newHost HostStruct
 	newHost.Name = hostname

--- a/vendor/github.com/lrsmith/go-icinga2-api/iapi/hosts.go
+++ b/vendor/github.com/lrsmith/go-icinga2-api/iapi/hosts.go
@@ -37,10 +37,14 @@ func (server *Server) CreateHost(hostname, address, checkCommand string, variabl
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
-	newAttrs.CheckCommand = "hostalive"
+	newAttrs.CheckCommand = checkCommand
 	newAttrs.Vars = variables
 	newAttrs.Templates = templates
-	newAttrs.Groups = groups
+
+        if groups == nil {
+          groups = []string{} 
+        }
+        newAttrs.Groups = groups
 
 	var newHost HostStruct
 	newHost.Name = hostname

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -515,10 +515,10 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
-			"checksumSHA1": "5vT6l22kAQVXWOT1YI5bhLQ9kBA=",
+			"checksumSHA1": "o2NFiTnCfAMIdWJWIsIeXcoQ1Ws=",
 			"path": "github.com/lrsmith/go-icinga2-api/iapi",
-			"revision": "7b46d425cc71344e4357bf0bcc873e93723d1dc7",
-			"revisionTime": "2017-07-26T19:48:34Z"
+			"revision": "2db1559a4428d87d5a495c88e98941a9fc27e888",
+			"revisionTime": "2017-11-20T19:25:49Z"
 		},
 		{
 			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",
@@ -636,5 +636,5 @@
 			"versionExact": "v1.6.1"
 		}
 	],
-	"rootPath": "github.com/terraform-providers/terraform-provider-icinga2"
+	"rootPath": "github.com/caseyr232/terraform-provider-icinga2"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -515,10 +515,12 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
-			"checksumSHA1": "o2NFiTnCfAMIdWJWIsIeXcoQ1Ws=",
+			"checksumSHA1": "Th3eV0kOgeIQaY8HmMQqlxD8/II=",
 			"path": "github.com/lrsmith/go-icinga2-api/iapi",
-			"revision": "2db1559a4428d87d5a495c88e98941a9fc27e888",
-			"revisionTime": "2017-11-20T19:25:49Z"
+			"revision": "1eefd51860db6050750b4f33d1fc0ae5ebc472ee",
+			"revisionTime": "2018-03-09T05:14:40Z",
+			"version": "v0.2.2",
+			"versionExact": "v0.2.2"
 		},
 		{
 			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",
@@ -636,5 +638,5 @@
 			"versionExact": "v1.6.1"
 		}
 	],
-	"rootPath": "github.com/caseyr232/terraform-provider-icinga2"
+	"rootPath": "github.com/terraform-providers/terraform-provider-icinga2"
 }


### PR DESCRIPTION
Based on and supercedes ([PR-8](https://github.com/terraform-providers/terraform-provider-icinga2/pull/8))

This PR includes casery232's fix for groups, when managing resources_icinga2_host object. It has been modified to make groups optional rather than required and govend in the correct version of go-icinga2-api, to support optionally delcaring groups, with hosts.


