### PR TITLE
tests: Configure provider before running test

### DIFF
--- a/icinga2/provider_test.go
+++ b/icinga2/provider_test.go
@@ -45,4 +45,8 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("ICINGA2_API_PASSWORD must be set for acceptance tests")
 	}
 
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This is to prevent the following test failure:

```
=== RUN   TestAccCreateHostNotification
--- FAIL: TestAccCreateHostNotification (0.00s)

------- Stderr: -------
2019/02/23 08:35:24 [WARN] Test: Executing step 0
panic: interface conversion: interface {} is nil, not *iapi.Server [recovered]
	panic: interface conversion: interface {} is nil, not *iapi.Server

goroutine 5 [running]:
testing.tRunner.func1(0xc00011a200)
	/opt/goenv/versions/1.11.5/src/testing/testing.go:792 +0x387
panic(0x96ee80, 0xc000196de0)
	/opt/goenv/versions/1.11.5/src/runtime/panic.go:513 +0x1b9
github.com/terraform-providers/terraform-provider-icinga2/icinga2.TestAccCreateHostNotification.func1()
	/opt/teamcity-agent/work/4a28996c8b7fc14/src/github.com/terraform-providers/terraform-provider-icinga2/icinga2/resource_icinga2_notification_test.go:23 +0x138
github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource.testModule(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/teamcity-agent/work/4a28996c8b7fc14/src/github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:664 +0x69a
github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource.testStep(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/teamcity-agent/work/4a28996c8b7fc14/src/github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:23 +0xbd
github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource.testStepConfig(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/teamcity-agent/work/4a28996c8b7fc14/src/github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go:16 +0x88
github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource.Test(0xae19c0, 0xc00011a200, 0x0, 0xc00019cb30, 0xc000196ba0, 0x0, 0x0, 0x0, 0xc0001859e0, 0x1, ...)
	/opt/teamcity-agent/work/4a28996c8b7fc14/src/github.com/terraform-providers/terraform-provider-icinga2/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:417 +0x1076
github.com/terraform-providers/terraform-provider-icinga2/icinga2.TestAccCreateHostNotification(0xc00011a200)
	/opt/teamcity-agent/work/4a28996c8b7fc14/src/github.com/terraform-providers/terraform-provider-icinga2/icinga2/resource_icinga2_notification_test.go:28 +0x3f5
testing.tRunner(0xc00011a200, 0xa36128)
	/opt/goenv/versions/1.11.5/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/opt/goenv/versions/1.11.5/src/testing/testing.go:878 +0x35c
```