### PR TITLE
Fixing two mistakes in maps.

### DIFF
--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -25,7 +25,7 @@ resource "icinga2_host" "host" {
   check_command = "hostalive"
   templates     = ["bp-host-web"]
 
-  vars {
+  vars = {
     os        = "linux"
     osver     = "1"
     allowance = "none"

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -23,7 +23,7 @@ resource "icinga2_service" "my-service" {
   name          = "ssh"
   hostname      = "c1-mysql-1"
   check_command = "ssh"
-  vars {
+  vars = {
     port        = "22"
   }
 }


### PR DESCRIPTION
A map needs a = fixing this in the two places it is wrong in the
documentation.